### PR TITLE
Add GitHub CI

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,18 @@
+name: DCO
+on:
+  pull_request:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Check DCO
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        pip3 install -U dco-check
+        dco-check --verbose

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - rolling
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            distro: rolling
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ros-tooling/setup-ros@master
+      with:
+        required-ros-distributions: ${{ matrix.distro }}
+        use-ros2-testing: true
+    - uses: ros-tooling/action-ros-ci@master
+      with:
+        package-name: ros_2cli
+        target-ros2-distro: ${{ matrix.distro }}


### PR DESCRIPTION
* Build and test using `setup-ros`/`action-ros-ci`
* Check DCO using https://github.com/christophebedard/dco-check

I tried to add a workflow that packages into a deb using https://github.com/jspricke/ros-deb-builder-action, but I was getting this error when installing:

```sh
$ sudo apt-get install -y ros-rolling-ros-2cli
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  ros-rolling-ros-2cli
0 upgraded, 1 newly installed, 0 to remove and 303 not upgraded.
Need to get 5,772 B of archives.
After this operation, 44.0 kB of additional disk space will be used.
Get:1 https://raw.githubusercontent.com/christophebedard/ros_2cli/jammy-rolling ./ ros-rolling-ros-2cli 0-2023.03.19.17.22 [5,772 B]
Fetched 5,772 B in 0s (14.0 kB/s)               
Selecting previously unselected package ros-rolling-ros-2cli.
(Reading database ... 554100 files and directories currently installed.)
Preparing to unpack .../ros-rolling-ros-2cli_0-2023.03.19.17.22_amd64.deb ...
Unpacking ros-rolling-ros-2cli (0-2023.03.19.17.22) ...
dpkg: error processing archive /var/cache/apt/archives/ros-rolling-ros-2cli_0-2023.03.19.17.22_amd64.deb (--unpack):
 trying to overwrite '/opt/ros/rolling/share/ros2cli/package.dsv', which is also in package ros-rolling-ros2cli 0.21.0-1jammy.20230120.194332
Errors were encountered while processing:
 /var/cache/apt/archives/ros-rolling-ros-2cli_0-2023.03.19.17.22_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```